### PR TITLE
Allow reductiondir existing

### DIFF
--- a/autoreduce_qp/queue_processor/reduction/service.py
+++ b/autoreduce_qp/queue_processor/reduction/service.py
@@ -88,7 +88,7 @@ class TemporaryReductionDirectory:
         :param destination: (Path like) the copy destination
         """
         logger.info("Copying %s to %s", self.path, destination)
-        copytree(self.path, str(destination))  # We have to convert path objects to str
+        copytree(self.path, str(destination), dirs_exist_ok=True)  # We have to convert path objects to str
 
     @property
     def path(self) -> str:

--- a/autoreduce_qp/queue_processor/reduction/service.py
+++ b/autoreduce_qp/queue_processor/reduction/service.py
@@ -12,7 +12,7 @@ import logging
 import os
 import traceback
 import types
-from distutils.dir_util import copy_tree
+from shutil import copytree
 from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -51,8 +51,7 @@ class ReductionDirectory:
         Creates the reduction directory including the log path, Script.out and Mantid.log files
         """
         logger.info("Creating reduction directory: %s", self.path)
-        os.umask(0)
-        os.makedirs(self.path, mode=0o777, exist_ok=False)
+        self.path.mkdir(parents=True, exist_ok=True)
         self.log_path.mkdir(exist_ok=True)
         self.script_log.touch(exist_ok=True)
         self.mantid_log.touch(exist_ok=True)
@@ -89,7 +88,7 @@ class TemporaryReductionDirectory:
         :param destination: (Path like) the copy destination
         """
         logger.info("Copying %s to %s", self.path, destination)
-        copy_tree(self.path, str(destination))  # We have to convert path objects to str
+        copytree(self.path, str(destination))  # We have to convert path objects to str
 
     @property
     def path(self) -> str:


### PR DESCRIPTION
## Why the change?

This error is occuring on reduction reruns:
```
"[09/Aug/2022 20:21:05] ERROR [autoreduce_qp.queue_processor.reduction:101] Traceback (most recent call last):
  File "/venv/lib/python3.8/site-packages/autoreduce_qp/queue_processor/reduction/runner.py", line 92, in _do_reduce
    reduce(reduction_dir, temp_dir, datafiles, reduction_script, self.reduction_arguments, reduction_log_stream)
  File "/venv/lib/python3.8/site-packages/autoreduce_qp/queue_processor/reduction/service.py", line 229, in reduce
    reduction_dir.create()
  File "/venv/lib/python3.8/site-packages/autoreduce_qp/queue_processor/reduction/service.py", line 55, in create
    os.makedirs(self.path, mode=0o777, exist_ok=False)
  File "/venv/lib/python3.8/os.py", line 223, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/instrument/MARI/RBNumber/RB2090091/autoreduced'"
```

On creating a reduction dir, it is failing if the RB folder / autoreduced already exists (which it would if re-running). Current implementation works for new runs (via run-detection) but not re-runs through the website.

## Fix

- Allow exist_ok=True for reduction dir (as it was till I changed it [here](https://github.com/autoreduction/queue-processor/commit/faad656e5e110f8376484323816b081d7e9d2994) whilst debugging and forgot to change it back)

## Other change

- Replace deprecated distutils usage (only one in whole project, crazy) with shutil for copytree