### PR TITLE
Add toml to mamba

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python=3.8
   - pip
   - matplotlib
+  - toml
   - pip:
     - . # Install local queue-processor
     - mysqlclient


### PR DESCRIPTION
Add toml to mamba as it is not currently installed by Mantid (will be in future)

### Summary of work
<!---The changes you have made--->

<!--- If having added new database query through Django ORM, check that you did it the best way possible: https://gist.github.com/rg3915/91766c2de54233541f6743edba44732c --->

### How to test your work
<!---This can be a link to the--->

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?--->

Fixes #xyz


**Before merging ensure the release notes have been updated**
