### PR TITLE
Fix tests by mostly reverting changes

### DIFF
--- a/autoreduce_qp/queue_processor/reduction/service.py
+++ b/autoreduce_qp/queue_processor/reduction/service.py
@@ -12,7 +12,7 @@ import logging
 import os
 import traceback
 import types
-from shutil import copytree
+from distutils.dir_util import copy_tree
 from importlib.util import spec_from_file_location, module_from_spec
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -51,7 +51,8 @@ class ReductionDirectory:
         Creates the reduction directory including the log path, Script.out and Mantid.log files
         """
         logger.info("Creating reduction directory: %s", self.path)
-        self.path.mkdir(parents=True, exist_ok=True)
+        os.umask(0)
+        os.makedirs(self.path, mode=0o777, exist_ok=True)
         self.log_path.mkdir(exist_ok=True)
         self.script_log.touch(exist_ok=True)
         self.mantid_log.touch(exist_ok=True)
@@ -88,7 +89,7 @@ class TemporaryReductionDirectory:
         :param destination: (Path like) the copy destination
         """
         logger.info("Copying %s to %s", self.path, destination)
-        copytree(self.path, str(destination), dirs_exist_ok=True)  # We have to convert path objects to str
+        copy_tree(self.path, str(destination))  # We have to convert path objects to str
 
     @property
     def path(self) -> str:


### PR DESCRIPTION
Revert back to disutils and os.makeidrs for systemtest permissions (but keep exist_ok=True).

If permission issues happen again with production runner-mantid, this is the change that probably will have done that. I believe it should be okay though