### PR TITLE
Use the DJANGO_SECRET_ENV environment variable for key

### DIFF
--- a/autoreduce_qp/autoreduce_django/settings.py
+++ b/autoreduce_qp/autoreduce_django/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
+import os
 from pathlib import Path
 
 from autoreduce_db.autoreduce_django.settings import DATABASES as autoreduce_db_settings
@@ -20,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-1_r@nia!d7&9q)yigp=+p5i)p@ei+b(#w71z4ap%)r$9g6-9i!'
+SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
### Summary of work
<!---The changes you have made--->
I checked that the queue-processor has the DJANGO_SECRET_ENV environment variable, in the k8s repo we have a secrets file [here](https://github.com/autoreduction/k8s/blob/b50f70f6506a6c3eab2d688713008e473f00191a/ansible/roles/queue_processor/templates/qp-secret.yaml#L8), and that is given the queue-processor in the k8s repo aswell as a secretRef in this [file](https://github.com/autoreduction/k8s/blob/b50f70f6506a6c3eab2d688713008e473f00191a/ansible/roles/queue_processor/templates/deployment.yaml#L31)

### How to test your work
<!---This can be a link to the--->
Just code review here.

### Additional comments
<!---Anything else: e.g. was the estimate reasonable for this issue?--->

Fixes #1483 


**Before merging ensure the release notes have been updated**
No release notes as not user facing and just a security update.